### PR TITLE
gh-92308: Add Pending Removal section to 3.11 What's New (C API Changes)

### DIFF
--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -1790,6 +1790,17 @@ Deprecated
 * Deprecate the ``ob_shash`` member of the :c:type:`PyBytesObject`. Use :c:func:`PyObject_Hash` instead.
   (Contributed by Inada Naoki in :issue:`46864`.)
 
+Pending Removal
+---------------
+
+Python 3.12
+^^^^^^^^^^^
+
+* The ``PyUnicode_InternImmortal()`` function is now deprecated
+  and will be removed in Python 3.12: use :c:func:`PyUnicode_InternInPlace`
+  instead.
+  (Contributed by Victor Stinner in :issue:`41692`.)
+
 Removed
 -------
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Add "What’s New In Python 3.10 > C API Changes > Deprecated"

to "What’s New In Python 3.11 > C API Changes > Pending Removal > Python 3.12"

https://docs.python.org/3.11/whatsnew/3.10.html#id3

No such section in:

* https://docs.python.org/3.11/whatsnew/3.9.html#changes-in-the-python-api
* https://docs.python.org/3.11/whatsnew/3.8.html#changes-in-the-python-api
* https://docs.python.org/3.11/whatsnew/3.7.html#changes-in-the-python-api
* https://docs.python.org/3.11/whatsnew/3.7.html#changes-in-the-python-api

(But I didn't check for deprecations mixed in the other sections.)