### PR TITLE
Don't reinvent the argparse wheel

### DIFF
--- a/Lib/test/test_clinic.py
+++ b/Lib/test/test_clinic.py
@@ -1626,7 +1626,7 @@ class ClinicExternalTest(TestCase):
 
     def test_cli_fail_output_and_multiple_files(self):
         _, err = self.expect_failure("-o", "out.c", "input.c", "moreinput.c")
-        msg = "Usage error: can't use -o with multiple filenames"
+        msg = "error: can't use -o with multiple filenames"
         self.assertIn(msg, err)
 
     def test_cli_fail_filename_or_output_and_make(self):
@@ -1638,7 +1638,7 @@ class ClinicExternalTest(TestCase):
 
     def test_cli_fail_make_without_srcdir(self):
         _, err = self.expect_failure("--make", "--srcdir", "")
-        msg = "Usage error: --srcdir must not be empty with --make"
+        msg = "error: --srcdir must not be empty with --make"
         self.assertIn(msg, err)
 
 


### PR DESCRIPTION
Rather than creating a custom `CLIError` class, we can just reuse argparse's already-implemented way of raising errors for bad command-line usage. It prints excellently formatted error messages to the terminal:

```
C:\Users\alexw\coding\cpython>python Tools/clinic/clinic.py -o foo --make
Running Release|x64 interpreter...
usage: clinic.py [-h] [-f] [-o OUTPUT] [-v] [--converters] [--make] [--srcdir SRCDIR] [FILE ...]
clinic.py: error: can't use -o or filenames with --make
```