### PR TITLE
Share more code between the `warn()` and `fail()` branches

### DIFF
--- a/Lib/test/test_clinic.py
+++ b/Lib/test/test_clinic.py
@@ -1446,8 +1446,12 @@ class ClinicParserTest(TestCase):
             self.parse(block)
         # The line numbers are off; this is a known limitation.
         expected = dedent("""\
-            Warning on line 0: Non-ascii characters are not allowed in docstrings: 'á'
-            Warning on line 0: Non-ascii characters are not allowed in docstrings: 'ü', 'á', 'ß'
+            Warning on line 0:
+            Non-ascii characters are not allowed in docstrings: 'á'
+
+            Warning on line 0:
+            Non-ascii characters are not allowed in docstrings: 'ü', 'á', 'ß'
+
         """)
         self.assertEqual(stdout.getvalue(), expected)
 


### PR DESCRIPTION
What do you think of this idea? I'm not a massive fan at the moment of how the code in `main()` for dealing with `ClinicError` exceptions basically duplicates the code in `warn_and_fail()` for constructing warning messages. By putting that code in a method on the `ClinicError` class, we can unify the two branches: